### PR TITLE
fix: detail view fruit image offset

### DIFF
--- a/shopping-app-ios/HomeScreenViews/FruitDetailsView.swift
+++ b/shopping-app-ios/HomeScreenViews/FruitDetailsView.swift
@@ -63,6 +63,7 @@ struct FruitDetailsView: View {
                         .resizable()
                         .frame(width: 250, height: 250, alignment: .center)
                         .shadow(color: .gray, radius: 5, x: 5, y: 5)
+                        .offset(y:50)
                 )
             Spacer()
             Text("\(fruit.rawValue) - Medium")


### PR DESCRIPTION
<h1>FIX - Cosmetic[Details View]</h1>
<table>
  <tr>
    <h2>Desription:</h2>
    <br />
   This PR corrects the Fruit Details View cosmetics:
   <br />
   Offset added to the fruit image on top to match the design.
   <br />
    <br />
  </tr>

  <tr>
    <td>BEFORE</td>
    <td>AFTER</td>
  </tr>
  <tr>
    <td>
      <img
        width="306"
        alt="Screenshot 2025-05-14 at 18 37 28"
        src="https://github.com/user-attachments/assets/f4fe7581-455a-44d8-afe5-55c3b807d840"
      />
    </td>
    <td>
      <img
        width="293"
        alt="Screenshot 2025-05-14 at 18 34 44"
        src="https://github.com/user-attachments/assets/952ac8d6-3664-4e8d-b084-7b063fc09db5"
      />
    </td>
  </tr>
</table>
